### PR TITLE
fix void portal crash

### DIFF
--- a/project/mods/Sulayre.Lure/Modules/Mapper.gd
+++ b/project/mods/Sulayre.Lure/Modules/Mapper.gd
@@ -57,7 +57,8 @@ func _load_map():
 			"bush",
 			"shoreline_point",
 			"trash_point",
-			"deep_spawn"
+			"deep_spawn",
+			"hidden_spot"
 			]
 		
 		var anticrash = Spatial.new()


### PR DESCRIPTION
fixes void portals crashing when spawning if there are no 'hidden_spot' nodes in the map